### PR TITLE
Resolve deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "halleck45/phpmetrics": ">=1.2.0"
+        "phpmetrics/phpmetrics": ">=1.2.0"
     },
     "require-dev": {
         "symfony/framework-bundle": ">=2.2,<3",


### PR DESCRIPTION
Solve message thrown by Composer during installation: "_**Package halleck45/phpmetrics is abandoned, you should avoid using it. Use phpmetrics/phpmetrics instead.**_"